### PR TITLE
Exclude RAM disks from ephemeral disk count

### DIFF
--- a/udf-common
+++ b/udf-common
@@ -6,7 +6,7 @@ FS_TYPE='ext4'
 EPHEMERAL_MOUNT_POINT='/opt/indix'
 
 ROOT_DEVICE=$(df -h | grep "/$" | awk '{ print $1 }' | awk -F '/' '{ print $3 }' | sed 's/.$//g')
-EPHEMERAL_DEVICES=$(cat /proc/partitions | sed -n '1,2!p' | grep -v ${ROOT_DEVICE} | awk '{ print "/dev/"$4 }')
+EPHEMERAL_DEVICES=$(cat /proc/partitions | sed -n '1,2!p' | grep -v "ram[0-9]*" | grep -v ${ROOT_DEVICE} | awk '{ print "/dev/"$4 }')
 EPHEMERAL_DEVICES_COUNT=$(cat /proc/partitions | sed -n '1,2!p' | grep -v ${ROOT_DEVICE} | wc -l)
 
 if [ ${EPHEMERAL_DEVICES_COUNT} -ne 0 ]; then


### PR DESCRIPTION
This PR excludes RAM disks from `$EPHEMERAL_DEVICES`.

This should ideally fix problems with mounting `/opt/indix`, like these —

```
[TIME [0m] Timed out waiting for device dev-disk-by\x2duuid.device.
[DEPEND[0m] Dependency failed for /opt/indix.
```

More context is on the #ops (private) channel. Many thanks to @G1GC for helping with the fix!